### PR TITLE
fix(config): correct status field typo in asset lists

### DIFF
--- a/blockchains/bsc/assets.mainnet.json
+++ b/blockchains/bsc/assets.mainnet.json
@@ -8913,7 +8913,7 @@
   ],
   "logoUri": "",
   "name": "Iron Wallet: Binance Smart Chain",
-  "statu": null,
+  "status": "active",
   "timestamp": "2024-10-25T23:13:44.399Z",
   "version": {
     "major": 0,

--- a/blockchains/ethereum/assets.mainnet.json
+++ b/blockchains/ethereum/assets.mainnet.json
@@ -16923,7 +16923,7 @@
   ],
   "logoUri": "",
   "name": "Iron Wallet: Ethereum",
-  "statu": null,
+  "status": "active",
   "timestamp": "2024-10-25T23:11:09.042Z",
   "version": {
     "major": 0,

--- a/blockchains/solana/assets.mainnet.json
+++ b/blockchains/solana/assets.mainnet.json
@@ -4788,7 +4788,7 @@
   ],
   "logoUri": "",
   "name": "Iron Wallet: Solana",
-  "statu": null,
+  "status": "active",
   "timestamp": "2025-01-21T23:15:30.610Z",
   "version": {
     "major": 0,


### PR DESCRIPTION
## Problem

Asset list files had a typo in the status field: "statu" instead of "status", with value null. This could cause NOT NULL violation or validation issues when the status field is required.

## Solution

- Renamed field from "statu" to "status".
- Set status value to "active" for BSC, Ethereum, and Solana mainnet asset lists.

## Affected

- blockchains/bsc/assets.mainnet.json
- blockchains/ethereum/assets.mainnet.json
- blockchains/solana/assets.mainnet.json