### PR TITLE
fix(token): remove assets exceeding field length limits

### DIFF
--- a/blockchains/bsc/assets.mainnet.json
+++ b/blockchains/bsc/assets.mainnet.json
@@ -8953,21 +8953,6 @@
             "type": "BEP20"
         },
         {
-            "address": "0x3fCD741646A9790635b938Cdb69af5Df356CbaAB",
-            "asset_id": "cmlrx4w15042hwgfmu2m0hy6g",
-            "chainId": 56,
-            "decimals": 18,
-            "default": false,
-            "displayDecimals": 4,
-            "explorer": "https://bscscan.com/token/0x3fcd741646a9790635b938cdb69af5df356cbaab",
-            "externalId": "abrdn-physical-palladium-shares-etf-ondo-tokenized-stocks",
-            "logoUri": "assets/cmlrx4w15042hwgfmu2m0hy6g/logo.png",
-            "name": "abrdn Physical Palladium Shares ETF (Ondo Tokenized ETF)",
-            "status": "active",
-            "symbol": "pallon",
-            "type": "BEP20"
-        },
-        {
             "address": "0x7aF44d51d1fb88c5b74Fc71d3cba649Bb8099D14",
             "asset_id": "cmlrx4w15042jwgfm5pdy4qmu",
             "chainId": 56,
@@ -9757,9 +9742,9 @@
             "explorer": "https://bscscan.com/token/0x924fa68a0fc644485b8df8abfa0a41c2e7744444",
             "externalId": "bianrensheng",
             "logoUri": "assets/cmlrx4w1d04ctwgfm1c4wl5ga/logo.png",
-            "name": "\u5e01\u5b89\u4eba\u751f (BinanceLife)",
+            "name": "币安人生 (BinanceLife)",
             "status": "active",
-            "symbol": "\u5e01\u5b89\u4eba\u751f",
+            "symbol": "币安人生",
             "type": "BEP20"
         },
         {
@@ -10672,9 +10657,9 @@
             "explorer": "https://bscscan.com/token/0x3ac8e2c113d5d7824ac6ebe82a3c60b1b9d64444",
             "externalId": "customer-service-xiao-he",
             "logoUri": "assets/cmlrx4w1m04qvwgfmq3jvo1t5/logo.png",
-            "name": "\u5ba2\u670d\u5c0f\u4f55 (Customer Service Xiao He)",
+            "name": "客服小何 (Customer Service Xiao He)",
             "status": "active",
-            "symbol": "\u5ba2\u670d\u5c0f\u4f55",
+            "symbol": "客服小何",
             "type": "BEP20"
         },
         {
@@ -11452,9 +11437,9 @@
             "explorer": "https://bscscan.com/token/0x82ec31d69b3c289e541b50e30681fd1acad24444",
             "externalId": "hakimi",
             "logoUri": "assets/cmlrx4w1u0568wgfmaxyybkdi/logo.png",
-            "name": "\u54c8\u57fa\u7c73 (Hajimi)",
+            "name": "哈基米 (Hajimi)",
             "status": "active",
-            "symbol": "\u54c8\u57fa\u7c73",
+            "symbol": "哈基米",
             "type": "BEP20"
         },
         {
@@ -11662,9 +11647,9 @@
             "explorer": "https://bscscan.com/token/0x6d8d8df799279e761a4f49edc319b3bd50f14444",
             "externalId": "i-am-the-future",
             "logoUri": "assets/cmlrx4w1w058wwgfmu1re0fn8/logo.png",
-            "name": "\u6211\u662f\u672a\u6765 (I am the Future)",
+            "name": "我是未来 (I am the Future)",
             "status": "active",
-            "symbol": "\u6211\u662f\u672a\u6765",
+            "symbol": "我是未来",
             "type": "BEP20"
         },
         {
@@ -11845,21 +11830,6 @@
             "name": "iShares Core S&P 500 ETF (Ondo Tokenized ETF)",
             "status": "active",
             "symbol": "ivvon",
-            "type": "BEP20"
-        },
-        {
-            "address": "0x08cE97F3D5Cf11E577D091ab048bC5e2EaE3FABB",
-            "asset_id": "cmlrx4w1x05atwgfmg5ksgb9d",
-            "chainId": 56,
-            "decimals": 18,
-            "default": false,
-            "displayDecimals": 4,
-            "explorer": "https://bscscan.com/token/0x08ce97f3d5cf11e577d091ab048bc5e2eae3fabb",
-            "externalId": "ishares-core-us-aggregate-bond-etf-ondo-tokenized-etf",
-            "logoUri": "assets/cmlrx4w1x05atwgfmg5ksgb9d/logo.png",
-            "name": "iShares Core US Aggregate Bond ETF (Ondo Tokenized ETF)",
-            "status": "active",
-            "symbol": "aggon",
             "type": "BEP20"
         },
         {
@@ -12112,9 +12082,9 @@
             "explorer": "https://bscscan.com/token/0x1a5f9d77ca46646cd4937fd8d093f460b66f4444",
             "externalId": "laozi",
             "logoUri": "assets/cmlrx4w1z05ewwgfmutv178q6/logo.png",
-            "name": "\u8001\u5b50 (Laozi)",
+            "name": "老子 (Laozi)",
             "status": "active",
-            "symbol": "\u8001\u5b50",
+            "symbol": "老子",
             "type": "BEP20"
         },
         {
@@ -12682,9 +12652,9 @@
             "explorer": "https://bscscan.com/token/0x51d5b1377b4d429283e8156540855ece77ad4444",
             "externalId": "minor-shareholder",
             "logoUri": "assets/cmlrx4w2405mrwgfmp0ymj07j/logo.png",
-            "name": "\u5c0f\u80a1\u4e1c (Minor Shareholder)",
+            "name": "小股东 (Minor Shareholder)",
             "status": "active",
-            "symbol": "\u5c0f\u80a1\u4e1c",
+            "symbol": "小股东",
             "type": "BEP20"
         },
         {
@@ -14407,7 +14377,7 @@
             "explorer": "https://bscscan.com/token/0x011ebe7d75e2c9d1e0bd0be0bef5c36f0a90075f",
             "externalId": "stable-2",
             "logoUri": "assets/cmlrx4w2j06a6wgfmfv0027mw/logo.png",
-            "name": "\u200b\u200bStable",
+            "name": "​​Stable",
             "status": "active",
             "symbol": "stable",
             "type": "BEP20"
@@ -14512,9 +14482,9 @@
             "explorer": "https://bscscan.com/token/0x730e9b7091258cdf578136ec8394daea2db84444",
             "externalId": "success-2",
             "logoUri": "assets/cmlrx4w2k06bfwgfmspqeuhpe/logo.png",
-            "name": "\u9a6c\u5230\u6210\u529f (Success)",
+            "name": "马到成功 (Success)",
             "status": "active",
-            "symbol": "\u9a6c\u5230\u6210\u529f",
+            "symbol": "马到成功",
             "type": "BEP20"
         },
         {
@@ -14680,21 +14650,6 @@
             "name": "Taiko",
             "status": "active",
             "symbol": "taiko",
-            "type": "BEP20"
-        },
-        {
-            "address": "0xC37042A7a4fa510D8884a433762aB87257B91965",
-            "asset_id": "cmlrx4w2l06clwgfmld5exy06",
-            "chainId": 56,
-            "decimals": 18,
-            "default": false,
-            "displayDecimals": 4,
-            "explorer": "https://bscscan.com/token/0xc37042a7a4fa510d8884a433762ab87257b91965",
-            "externalId": "taiwan-semiconductor-manufacturing-ondo-tokenized-stock",
-            "logoUri": "assets/cmlrx4w2l06clwgfmld5exy06/logo.png",
-            "name": "Taiwan Semiconductor Manufacturing (Ondo Tokenized Stock)",
-            "status": "active",
-            "symbol": "tsmon",
             "type": "BEP20"
         },
         {
@@ -15367,9 +15322,9 @@
             "explorer": "https://bscscan.com/token/0xe1e93e92c0c2aff2dc4d7d4a8b250d973cad4444",
             "externalId": "vulgar-penguin",
             "logoUri": "assets/cmlrx4w2r06lbwgfm7deavfxx/logo.png",
-            "name": "\u4e09\u7ef4\u5a01\u5ec9\u6cf0\u5c14\u4f01\u9e45 (Vulgar Penguin)",
+            "name": "三维威廉泰尔企鹅 (Vulgar Penguin)",
             "status": "active",
-            "symbol": "\u6076\u4fd7\u4f01\u9e45",
+            "symbol": "恶俗企鹅",
             "type": "BEP20"
         },
         {
@@ -15502,9 +15457,9 @@
             "explorer": "https://bscscan.com/token/0xc51a9250795c0186a6fb4a7d20a90330651e4444",
             "externalId": "wo-ta-ma-laile",
             "logoUri": "assets/cmlrx4w2s06nhwgfma16z2yty/logo.png",
-            "name": "\u6211\u8e0f\u9a6c\u6765\u4e86",
+            "name": "我踏马来了",
             "status": "active",
-            "symbol": "\u6211\u8e0f\u9a6c\u6765\u4e86",
+            "symbol": "我踏马来了",
             "type": "BEP20"
         },
         {
@@ -15622,9 +15577,9 @@
             "explorer": "https://bscscan.com/token/0x36f2fd027f5f27c59b8c6d64df64bcc8e8c97777",
             "externalId": "xuequi",
             "logoUri": "assets/cmlrx4w2t06p0wgfml3mbkoac/logo.png",
-            "name": "\u96ea\u7403 (Snowball)",
+            "name": "雪球 (Snowball)",
             "status": "active",
-            "symbol": "\u96ea\u7403",
+            "symbol": "雪球",
             "type": "BEP20"
         },
         {

--- a/blockchains/ethereum/assets.mainnet.json
+++ b/blockchains/ethereum/assets.mainnet.json
@@ -3982,7 +3982,7 @@
             "explorer": "https://etherscan.io/token/0xfb19075d77a0f111796fb259819830f4780f1429",
             "externalId": "fenerbahce-token",
             "logoUri": "assets/clh9g2u09012fb0g4bsrbocpq/logo.png",
-            "name": "Fenerbah\u00e7e",
+            "name": "Fenerbahçe",
             "status": "active",
             "symbol": "fb",
             "type": "ERC20"
@@ -9502,7 +9502,7 @@
             "explorer": "https://etherscan.io/token/0x8c688327c9371bb3bd69f6e1f1a6d8c9ca0880a7",
             "externalId": "dada-2",
             "logoUri": "assets/clswxoars00xx8cuhtpa7hvab/logo.png",
-            "name": "\u9f98\u9f98 D\u00e1D\u00e1",
+            "name": "龘龘 DáDá",
             "status": "active",
             "symbol": "dada",
             "type": "ERC20"
@@ -11604,7 +11604,7 @@
             "logoUri": "assets/clswxoatn02um8cuhdmynbd85/logo.png",
             "name": "Real Smurf Cat",
             "status": "active",
-            "symbol": "\u0448\u0430\u0439\u043b\u0443\u0448\u0430\u0439",
+            "symbol": "шайлушай",
             "type": "ERC20"
         },
         {
@@ -13252,7 +13252,7 @@
             "explorer": "https://etherscan.io/token/0x1903be033d3e436dd79a8cf9030675bcf97ab589",
             "externalId": "besiktas",
             "logoUri": "assets/cm2pciyfm00fwuwosw7wtkztu/logo.png",
-            "name": "Be\u015fikta\u015f",
+            "name": "Beşiktaş",
             "status": "active",
             "symbol": "bjk",
             "type": "ERC20"
@@ -16978,21 +16978,6 @@
             "type": "ERC20"
         },
         {
-            "address": "0x0cE36d199bd6851788e03392568849394cBdE722",
-            "asset_id": "cmlrwqei7003owgfmlbe2umsb",
-            "chainId": 1,
-            "decimals": 18,
-            "default": false,
-            "displayDecimals": 4,
-            "explorer": "https://etherscan.io/token/0x0ce36d199bd6851788e03392568849394cbde722",
-            "externalId": "abrdn-physical-palladium-shares-etf-ondo-tokenized-stocks",
-            "logoUri": "assets/cmlrwqei7003owgfmlbe2umsb/logo.png",
-            "name": "abrdn Physical Palladium Shares ETF (Ondo Tokenized ETF)",
-            "status": "active",
-            "symbol": "pallon",
-            "type": "ERC20"
-        },
-        {
             "address": "0xAbA9Ae731Aad63335C604E5f6E6A5db2e05f549d",
             "asset_id": "cmlrwqei7003qwgfm9nwhofah",
             "chainId": 1,
@@ -18925,21 +18910,6 @@
             "name": "iShares Core S&P 500 ETF (Ondo Tokenized ETF)",
             "status": "active",
             "symbol": "ivvon",
-            "type": "ERC20"
-        },
-        {
-            "address": "0xfF7CF16aA2fFc463b996DB2f7B7cf0130336899D",
-            "asset_id": "cmlrwqej401tnwgfme0wnuhut",
-            "chainId": 1,
-            "decimals": 18,
-            "default": false,
-            "displayDecimals": 4,
-            "explorer": "https://etherscan.io/token/0xff7cf16aa2ffc463b996db2f7b7cf0130336899d",
-            "externalId": "ishares-core-us-aggregate-bond-etf-ondo-tokenized-etf",
-            "logoUri": "assets/cmlrwqej401tnwgfme0wnuhut/logo.png",
-            "name": "iShares Core US Aggregate Bond ETF (Ondo Tokenized ETF)",
-            "status": "active",
-            "symbol": "aggon",
             "type": "ERC20"
         },
         {
@@ -21460,21 +21430,6 @@
             "name": "syrupUSDT",
             "status": "active",
             "symbol": "syrupusdt",
-            "type": "ERC20"
-        },
-        {
-            "address": "0x3Cafdbfe682aec17d5acE2f97A2f3ab3dCf6a4A9",
-            "asset_id": "cmlrwqek003f7wgfmi3w5lp6o",
-            "chainId": 1,
-            "decimals": 18,
-            "default": false,
-            "displayDecimals": 4,
-            "explorer": "https://etherscan.io/token/0x3cafdbfe682aec17d5ace2f97a2f3ab3dcf6a4a9",
-            "externalId": "taiwan-semiconductor-manufacturing-ondo-tokenized-stock",
-            "logoUri": "assets/cmlrwqek003f7wgfmi3w5lp6o/logo.png",
-            "name": "Taiwan Semiconductor Manufacturing (Ondo Tokenized Stock)",
-            "status": "active",
-            "symbol": "tsmon",
             "type": "ERC20"
         },
         {

--- a/blockchains/info.json
+++ b/blockchains/info.json
@@ -19,7 +19,7 @@
       "version": {
         "major": 0,
         "minor": 5,
-        "patch": 5
+        "patch": 6
       }
     },
     {
@@ -63,7 +63,7 @@
       "version": {
         "major": 0,
         "minor": 2,
-        "patch": 8
+        "patch": 9
       }
     },
     {
@@ -151,7 +151,7 @@
       "version": {
         "major": 0,
         "minor": 4,
-        "patch": 1
+        "patch": 2
       }
     },
     {

--- a/blockchains/solana/assets.mainnet.json
+++ b/blockchains/solana/assets.mainnet.json
@@ -3007,9 +3007,9 @@
             "explorer": "https://explorer.solana.com/address/8C5wsKz682s8ByYLxVpY8J3GHSAHTsT4fJPfT97Npump",
             "externalId": "m-ga",
             "logoUri": "assets/cm2pcoka608l2uwosc7rqn3ed/logo.png",
-            "name": "\u03a9M\u03a3GA",
+            "name": "ΩMΣGA",
             "status": "active",
-            "symbol": "$\u03c9m\u03c3ga",
+            "symbol": "$ωmσga",
             "type": "Solana"
         },
         {
@@ -3787,7 +3787,7 @@
             "explorer": "https://explorer.solana.com/address/2oGLxYuNBJRcepT1mEV6KnETaLD7Bf6qq3CM6skasBfe",
             "externalId": "rune-pups",
             "logoUri": "assets/cm2pcoka708wxuwospffva7x9/logo.png",
-            "name": "PUPS\u2022WORLD\u2022PEACE",
+            "name": "PUPS•WORLD•PEACE",
             "status": "active",
             "symbol": "pups",
             "type": "Solana"
@@ -4783,21 +4783,6 @@
             "type": "Solana"
         },
         {
-            "address": "GMvCfcZg8YvkkQmwDaAzCtHDrrEtgE74nQpQ7xNabonk",
-            "asset_id": "cmlrxmbq907zfwgfmsav6v231",
-            "chainId": 1,
-            "decimals": 6,
-            "default": false,
-            "displayDecimals": 4,
-            "explorer": "https://explorer.solana.com/address/GMvCfcZg8YvkkQmwDaAzCtHDrrEtgE74nQpQ7xNabonk",
-            "externalId": "1-coin-can-change-your-life",
-            "logoUri": "assets/cmlrxmbq907zfwgfmsav6v231/logo.png",
-            "name": "1 Coin Can Change Your Life",
-            "status": "active",
-            "symbol": "1-coin-can-change-your-life",
-            "type": "Solana"
-        },
-        {
             "address": "4vGHdzcNrDf8XVE8H19Rqea86RULz7xi89ew1sSJpump",
             "asset_id": "cmlrxmbq90800wgfmwhozv6lq",
             "chainId": 1,
@@ -4855,21 +4840,6 @@
             "name": "AbbVie (Ondo Tokenized Stock)",
             "status": "active",
             "symbol": "abbvon",
-            "type": "Solana"
-        },
-        {
-            "address": "P7hTXnKk2d2DyqWnefp5BSroE1qjjKpKxg9SxQqondo",
-            "asset_id": "cmlrxmbq90812wgfmjm8vc5jq",
-            "chainId": 1,
-            "decimals": 9,
-            "default": false,
-            "displayDecimals": 4,
-            "explorer": "https://explorer.solana.com/address/P7hTXnKk2d2DyqWnefp5BSroE1qjjKpKxg9SxQqondo",
-            "externalId": "abrdn-physical-palladium-shares-etf-ondo-tokenized-stocks",
-            "logoUri": "assets/cmlrxmbq90812wgfmjm8vc5jq/logo.png",
-            "name": "abrdn Physical Palladium Shares ETF (Ondo Tokenized ETF)",
-            "status": "active",
-            "symbol": "pallon",
             "type": "Solana"
         },
         {
@@ -5422,9 +5392,9 @@
             "explorer": "https://explorer.solana.com/address/DMYNp65mub3i7LRpBdB66CgBAceLcQnv4gsWeCi6pump",
             "externalId": "bingwu",
             "logoUri": "assets/cmlrxmbqc08fdwgfmm8ofmcou/logo.png",
-            "name": "b\u01d0ngw\u01d4",
+            "name": "bǐngwǔ",
             "status": "active",
-            "symbol": "\u4e19\u5348",
+            "symbol": "丙午",
             "type": "Solana"
         },
         {
@@ -7183,21 +7153,6 @@
             "type": "Solana"
         },
         {
-            "address": "13qTjKx53y6LKGGStiKeieGbnVx3fx1bbwopKFb3ondo",
-            "asset_id": "cmlrxmbqn09vewgfmpoxobu13",
-            "chainId": 1,
-            "decimals": 9,
-            "default": false,
-            "displayDecimals": 4,
-            "explorer": "https://explorer.solana.com/address/13qTjKx53y6LKGGStiKeieGbnVx3fx1bbwopKFb3ondo",
-            "externalId": "ishares-core-us-aggregate-bond-etf-ondo-tokenized-etf",
-            "logoUri": "assets/cmlrxmbqn09vewgfmpoxobu13/logo.png",
-            "name": "iShares Core US Aggregate Bond ETF (Ondo Tokenized ETF)",
-            "status": "active",
-            "symbol": "aggon",
-            "type": "Solana"
-        },
-        {
             "address": "M77ZvkZ8zW5udRbuJCbuwSwavRa7bGAZYMTwru8ondo",
             "asset_id": "cmlrxmbqn09vgwgfmbuwslvzc",
             "chainId": 1,
@@ -8602,9 +8557,9 @@
             "explorer": "https://explorer.solana.com/address/GoPffEZ5yuWNnBuUCmwx9idbH9D63xATkrGa6E9kpump",
             "externalId": "redacted-3",
             "logoUri": "assets/cmlrxmbqw0b4gwgfmzgbnuvsj/logo.png",
-            "name": "\u2588\u2588\u2588\u2588",
+            "name": "████",
             "status": "active",
-            "symbol": "\u2588\u2588\u2588\u2588",
+            "symbol": "████",
             "type": "Solana"
         },
         {
@@ -9340,21 +9295,6 @@
             "name": "syrupUSDC",
             "status": "active",
             "symbol": "syrupusdc",
-            "type": "Solana"
-        },
-        {
-            "address": "keybg184d4vyXeQdFqs4o99YsMg7xBthxTJ6Ky3ondo",
-            "asset_id": "cmlrxmbqz0bq5wgfmtie6f2dv",
-            "chainId": 1,
-            "decimals": 9,
-            "default": false,
-            "displayDecimals": 4,
-            "explorer": "https://explorer.solana.com/address/keybg184d4vyXeQdFqs4o99YsMg7xBthxTJ6Ky3ondo",
-            "externalId": "taiwan-semiconductor-manufacturing-ondo-tokenized-stock",
-            "logoUri": "assets/cmlrxmbqz0bq5wgfmtie6f2dv/logo.png",
-            "name": "Taiwan Semiconductor Manufacturing (Ondo Tokenized Stock)",
-            "status": "active",
-            "symbol": "tsmon",
             "type": "Solana"
         },
         {
@@ -10177,7 +10117,7 @@
             "explorer": "https://explorer.solana.com/address/F7pB3ZdfBnyFw2LRHydWEn9BmhEa5XihXLjhySFRpump",
             "externalId": "you-ll-own-nothing-and-be-happy",
             "logoUri": "assets/cmlrxmbr40cc8wgfmabhvglq6/logo.png",
-            "name": "You\u2019ll Own Nothing and Be Happy",
+            "name": "You’ll Own Nothing and Be Happy",
             "status": "active",
             "symbol": "nothing",
             "type": "Solana"
@@ -10282,7 +10222,7 @@
             "explorer": "https://explorer.solana.com/address/GnFMf6JVRhAqPbA9r8yW16xycynKNkXfbaYbusLEpump",
             "externalId": "zreal-super-coin",
             "logoUri": "assets/cmlrxmbr40cf0wgfmz9cm12ze/logo.png",
-            "name": "Z\u674eREAL SUPER COIN",
+            "name": "Z李REAL SUPER COIN",
             "status": "active",
             "symbol": "zreal",
             "type": "Solana"


### PR DESCRIPTION
## Problem

Assets with name > 50, externalId > 50, or symbol > 15 characters caused "value too long for type character varying(50)" when ConfigurationApi processes source-change.

## Solution

- Removed 10 assets from BSC, Ethereum, and Solana that exceeded length limits.
- Affected tokens: abrdn Physical Palladium Shares ETF (Ondo), iShares Core US Aggregate Bond ETF (Ondo), Taiwan Semiconductor Manufacturing (Ondo), 1 Coin Can Change Your Life.

## Affected

- blockchains/bsc/assets.mainnet.json
- blockchains/ethereum/assets.mainnet.json
- blockchains/solana/assets.mainnet.json
- blockchains/info.json