### PR TITLE
UGOLD token was missing from Ethereum asset list.

### DIFF
--- a/blockchains/ethereum/assets.mainnet.json
+++ b/blockchains/ethereum/assets.mainnet.json
@@ -22316,6 +22316,21 @@
             "status": "active",
             "symbol": "znd",
             "type": "ERC20"
+        },
+		{
+            "address": "0x6aBBF52276856DAb63c5DeE566965aA1a5fAe664",
+            "asset_id": "cm2pciygd03meuwos4kdffrmz",
+            "chainId": 1,
+            "decimals": 18,
+            "default": false,
+            "displayDecimals": 4,
+            "explorer": "https://etherscan.io/token/0x6aBBF52276856DAb63c5DeE566965aA1a5fAe664",
+            "externalId": "ugold-inc",
+            "logoUri": "assets/cm2pciygd03meuwos4kdffrmz/logo.png",
+            "name": "UGOLD",
+            "status": "active",
+            "symbol": "ugold",
+            "type": "ERC20"
         }
     ],
     "logoUri": "",

--- a/blockchains/info.json
+++ b/blockchains/info.json
@@ -15,11 +15,11 @@
       "blockchain": "ethereum",
       "chainId": 1,
       "list": "assets.mainnet.json",
-      "timestamp": "2026-02-18T11:46:07.865Z",
+      "timestamp": "2026-02-27T11:46:07.865Z",
       "version": {
         "major": 0,
         "minor": 5,
-        "patch": 6
+        "patch": 7
       }
     },
     {


### PR DESCRIPTION
## Problem
UGOLD token was missing from Ethereum asset list.

## Solution

- Added UGOLD token to Ethereum mainnet assets.
- Updated blockchains/info.json version metadata.

## Affected

- blockchains/ethereum/assets.mainnet.json
- blockchains/info.json
- blockchains/ethereum/assets/cm2pciygd03meuwos4kdffrmz/