### PR TITLE
config/update-info-versions

### DIFF
--- a/blockchains/info.json
+++ b/blockchains/info.json
@@ -257,11 +257,11 @@
       "blockchain": "base",
       "chainId": 8453,
       "list": "assets.mainnet.json",
-      "timestamp": "2026-02-18T11:46:07.865Z",
+      "timestamp": "2026-03-04T08:46:07.865Z",
       "version": {
         "major": 0,
         "minor": 1,
-        "patch": 0
+        "patch": 6
       }
     }
   ]


### PR DESCRIPTION
## Problem

Version metadata in blockchains/info.json was out of sync across networks.

## Solution

- Updated version patch numbers for BSC, Polygon, Arbitrum, Avalanche, Base, Optimism.
- Adjusted Ethereum list timestamp.

## Affected

- blockchains/info.json