### PR TITLE
Update info.json versions (Ethereum 0.6.0, Base 0.1.9) and UGOLD externalId

### DIFF
--- a/blockchains/ethereum/assets.mainnet.json
+++ b/blockchains/ethereum/assets.mainnet.json
@@ -22325,7 +22325,7 @@
             "default": false,
             "displayDecimals": 4,
             "explorer": "https://etherscan.io/token/0x6aBBF52276856DAb63c5DeE566965aA1a5fAe664",
-            "externalId": "ugold-inc",
+            "externalId": "ugold-inc-2",
             "logoUri": "assets/cmm508khr00009wfmdl831ens/logo.png",
             "name": "UGOLD",
             "status": "active",

--- a/blockchains/info.json
+++ b/blockchains/info.json
@@ -257,11 +257,11 @@
       "blockchain": "base",
       "chainId": 8453,
       "list": "assets.mainnet.json",
-      "timestamp": "2026-03-10T09:46:08.887Z",
+      "timestamp": "2026-03-11T09:46:08.887Z",
       "version": {
         "major": 0,
         "minor": 1,
-        "patch": 8
+        "patch": 9
       }
     }
   ]

--- a/blockchains/info.json
+++ b/blockchains/info.json
@@ -257,11 +257,11 @@
       "blockchain": "base",
       "chainId": 8453,
       "list": "assets.mainnet.json",
-      "timestamp": "2026-03-10T013:46:07.865Z",
+      "timestamp": "2026-03-10T09:46:08.887Z",
       "version": {
         "major": 0,
         "minor": 1,
-        "patch": 7
+        "patch": 8
       }
     }
   ]

--- a/blockchains/info.json
+++ b/blockchains/info.json
@@ -257,11 +257,11 @@
       "blockchain": "base",
       "chainId": 8453,
       "list": "assets.mainnet.json",
-      "timestamp": "2026-03-04T08:46:07.865Z",
+      "timestamp": "2026-03-10T013:46:07.865Z",
       "version": {
         "major": 0,
         "minor": 1,
-        "patch": 6
+        "patch": 7
       }
     }
   ]

--- a/blockchains/info.json
+++ b/blockchains/info.json
@@ -15,11 +15,11 @@
       "blockchain": "ethereum",
       "chainId": 1,
       "list": "assets.mainnet.json",
-      "timestamp": "2026-03-04T08:46:07.865Z",
+      "timestamp": "2026-05-20T08:46:07.865Z",
       "version": {
         "major": 0,
-        "minor": 5,
-        "patch": 9
+        "minor": 6,
+        "patch": 0
       }
     },
     {


### PR DESCRIPTION
## Summary

Small metadata release from **staging** into **main**. Updates list version timestamps in `info.json` and fixes the UGOLD token `externalId` on Ethereum.

**2 files changed** · 8 additions · 8 deletions

---

## Changes

### Ethereum (`blockchains/ethereum/assets.mainnet.json`)

- **UGOLD** (`0x6aBBF52276856DAb63c5DeE566965aA1a5fAe664`): `externalId` `ugold-inc` → `ugold-inc-2`

### Config (`blockchains/info.json`)

| Network  | Change |
|----------|--------|
| Ethereum | `timestamp` → `2026-05-20T08:46:07.865Z`, version `0.5.9` → **`0.6.0`** |
| Base     | `timestamp` → `2026-03-11T09:46:08.887Z`, patch `0.1.6` → **`0.1.9`** |

---

## Commits included

- Base info version bumps (#209, #210, #211)
- UGOLD `externalId` fix + `info.json` update (#212)

---

## Test plan

- [ ] `blockchains/info.json` reflects Ethereum `0.6.0` and Base `0.1.9`
- [ ] UGOLD on Ethereum uses `externalId: "ugold-inc-2"`
- [ ] Asset lists parse without JSON errors