### PR TITLE
fix(token): promote staging to main (remove A7A5 and HTX DAO)

### DIFF
--- a/blockchains/bsc/assets.mainnet.json
+++ b/blockchains/bsc/assets.mainnet.json
@@ -7588,21 +7588,6 @@
             "type": "BEP20"
         },
         {
-            "address": "0x61EC85aB89377db65762E234C946b5c25A56E99e",
-            "asset_id": "cm2pcmabb0528uwosgeu2e9wl",
-            "chainId": 56,
-            "decimals": 18,
-            "default": false,
-            "displayDecimals": 4,
-            "explorer": "https://bscscan.com/token/0x61ec85ab89377db65762e234c946b5c25a56e99e",
-            "externalId": "htx-dao",
-            "logoUri": "assets/cm2pcmabb0528uwosgeu2e9wl/logo.png",
-            "name": "HTX DAO",
-            "status": "active",
-            "symbol": "htx",
-            "type": "BEP20"
-        },
-        {
             "address": "0x7881cD2B5724431372F57C50E91611352557A606",
             "asset_id": "cm2pcmabb052ouwosrslalal6",
             "chainId": 56,
@@ -15766,10 +15751,10 @@
     "logoUri": "",
     "name": "Iron Wallet: Binance Smart Chain",
     "status": "active",
-    "timestamp": "2026-02-18T10:58:01.449Z",
+    "timestamp": "2026-05-28T11:59:32.132Z",
     "version": {
         "major": 0,
         "minor": 2,
-        "patch": 8
+        "patch": 9
     }
 }

--- a/blockchains/ethereum/assets.mainnet.json
+++ b/blockchains/ethereum/assets.mainnet.json
@@ -14353,21 +14353,6 @@
             "type": "ERC20"
         },
         {
-            "address": "0x61EC85aB89377db65762E234C946b5c25A56E99e",
-            "asset_id": "cm2pciyfx01rjuwosnrflf3zv",
-            "chainId": 1,
-            "decimals": 18,
-            "default": false,
-            "displayDecimals": 4,
-            "explorer": "https://etherscan.io/token/0x61ec85ab89377db65762e234c946b5c25a56e99e",
-            "externalId": "htx-dao",
-            "logoUri": "assets/cm2pciyfx01rjuwosnrflf3zv/logo.png",
-            "name": "HTX DAO",
-            "status": "active",
-            "symbol": "htx",
-            "type": "ERC20"
-        },
-        {
             "address": "0xEC12BA5AC0F259e9ac6FC9A3bC23a76Ad2fDE5D9",
             "asset_id": "cm2pciyfx01rluwosg27c24rm",
             "chainId": 1,
@@ -16870,21 +16855,6 @@
             "name": "THREE",
             "status": "active",
             "symbol": "$three",
-            "type": "ERC20"
-        },
-        {
-            "address": "0x6fA0BE17e4beA2fCfA22ef89BF8ac9aab0AB0fc9",
-            "asset_id": "cmciwg0qb000001o6vws5x9ci",
-            "chainId": 1,
-            "decimals": 6,
-            "default": false,
-            "displayDecimals": 4,
-            "explorer": "https://etherscan.io/token/0x6fA0BE17e4beA2fCfA22ef89BF8ac9aab0AB0fc9",
-            "externalId": "a7a5",
-            "logoUri": "assets/cmciwg0qb000001o6vws5x9ci/logo.png",
-            "name": "A7A5",
-            "status": "active",
-            "symbol": "a7a5",
             "type": "ERC20"
         },
         {
@@ -22336,10 +22306,10 @@
     "logoUri": "",
     "name": "Iron Wallet: Ethereum",
     "status": "active",
-    "timestamp": "2026-02-18T10:46:45.569Z",
+    "timestamp": "2026-05-28T11:59:32.132Z",
     "version": {
         "major": 0,
         "minor": 5,
-        "patch": 5
+        "patch": 6
     }
 }

--- a/blockchains/info.json
+++ b/blockchains/info.json
@@ -15,11 +15,11 @@
       "blockchain": "ethereum",
       "chainId": 1,
       "list": "assets.mainnet.json",
-      "timestamp": "2026-05-20T08:46:07.865Z",
+      "timestamp": "2026-05-28T11:59:32.132Z",
       "version": {
         "major": 0,
         "minor": 6,
-        "patch": 0
+        "patch": 1
       }
     },
     {
@@ -59,11 +59,11 @@
       "blockchain": "bsc",
       "chainId": 56,
       "list": "assets.mainnet.json",
-      "timestamp": "2026-02-18T11:46:07.865Z",
+      "timestamp": "2026-05-28T11:59:32.132Z",
       "version": {
         "major": 0,
         "minor": 3,
-        "patch": 0
+        "patch": 1
       }
     },
     {
@@ -81,11 +81,11 @@
       "blockchain": "tron",
       "chainId": 1,
       "list": "assets.mainnet.json",
-      "timestamp": "2026-02-18T11:46:07.865Z",
+      "timestamp": "2026-05-28T11:59:32.132Z",
       "version": {
         "major": 0,
         "minor": 2,
-        "patch": 5
+        "patch": 6
       }
     },
     {

--- a/blockchains/tron/assets.mainnet.json
+++ b/blockchains/tron/assets.mainnet.json
@@ -328,21 +328,6 @@
             "type": "TRC20"
         },
         {
-            "address": "TUPM7K8REVzD2UdV4R5fe5M8XbnR2DdoJ6",
-            "asset_id": "cm2pcntce06f5uwosnb5drivm",
-            "chainId": 1,
-            "decimals": 18,
-            "default": false,
-            "displayDecimals": 4,
-            "explorer": "https://tronscan.org/#/token20/TUPM7K8REVzD2UdV4R5fe5M8XbnR2DdoJ6",
-            "externalId": "htx-dao",
-            "logoUri": "assets/cm2pcntce06f5uwosnb5drivm/logo.png",
-            "name": "HTX DAO",
-            "status": "active",
-            "symbol": "htx",
-            "type": "TRC20"
-        },
-        {
             "address": "TSig7sWzEL2K83mkJMQtbyPpiVSbR6pZnb",
             "asset_id": "cm2pcntce06f6uwosg7ljwq2c",
             "chainId": 1,
@@ -445,21 +430,6 @@
             "name": "Zedxion",
             "status": "active",
             "symbol": "zedxion",
-            "type": "TRC20"
-        },
-        {
-            "address": "tlevfrdym8rojrej23dagyfjdygrtiwkbz",
-            "asset_id": "cmciwhnst000101o6owg5fv6t",
-            "chainId": 1,
-            "decimals": 6,
-            "default": false,
-            "displayDecimals": 4,
-            "explorer": "https://etherscan.io/token/0x6fA0BE17e4beA2fCfA22ef89BF8ac9aab0AB0fc9",
-            "externalId": "a7a5",
-            "logoUri": "assets/cmciwhnst000101o6owg5fv6t/logo.png",
-            "name": "A7A5",
-            "status": "active",
-            "symbol": "a7a5",
             "type": "TRC20"
         },
         {
@@ -586,10 +556,10 @@
     "logoUri": "",
     "name": "Iron Wallet: Tron",
     "status": "active",
-    "timestamp": "2026-02-18T11:08:37.885Z",
+    "timestamp": "2026-05-28T11:59:32.132Z",
     "version": {
         "major": 0,
         "minor": 2,
-        "patch": 5
+        "patch": 6
     }
 }


### PR DESCRIPTION
## Summary

Promotes `staging` into `main` with token cleanup changes already validated in staging.

This release removes A7A5 and HTX DAO tokens from mainnet asset lists and updates related version metadata.

## Included commits

- `e087291` Merge pull request #214 from Ironwallet/feature/remove-a7a5-htx-tokens
- `2196b31` fix(token): remove A7A5 and HTX DAO from mainnet asset lists

## Changes

- Removed **HTX DAO** from:
  - `blockchains/ethereum/assets.mainnet.json`
  - `blockchains/bsc/assets.mainnet.json`
  - `blockchains/tron/assets.mainnet.json`
- Removed **A7A5** from:
  - `blockchains/ethereum/assets.mainnet.json`
  - `blockchains/tron/assets.mainnet.json`
- Updated timestamps and patch versions in:
  - `blockchains/ethereum/assets.mainnet.json`
  - `blockchains/bsc/assets.mainnet.json`
  - `blockchains/tron/assets.mainnet.json`
  - `blockchains/info.json` (Ethereum/BSC/Tron mainnet entries)

## Verification

- [x] `staging` is up-to-date on remote
- [x] No remaining `"name": "A7A5"` in any `assets.mainnet.json`
- [x] No remaining `"name": "HTX DAO"` in any `assets.mainnet.json`
- [x] JSON parsing passes for all modified files
- [x] Diff scope confirmed: 4 files, +12 / -87